### PR TITLE
Add FDV and volume to supported asset details

### DIFF
--- a/variational/models.py
+++ b/variational/models.py
@@ -556,6 +556,8 @@ class SupportedAssetDetails(TypedDict):
     variational_funding_rate_params: FundingRateParams
     precision_requirements: Optional[PrecisionRequirements]
     min_qty_tick: Optional[StrDecimal]
+    fdv: Optional[StrDecimal]
+    volume_24h: Optional[StrDecimal]
 
 
 class Trade(TypedDict):


### PR DESCRIPTION
As per the title, this adds two fields to the SupportedAssetDetails:
- `fdv`
- `volume_24h`

These are already provided by the backend, so the only change here is exposing them.